### PR TITLE
Nextcloud cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 COMMON_OVERLAYS = github-latest-release
 
+PHP_VERSION=7.2
+
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
+COMMON_OVERLAYS = github-latest-release
+
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/changelog
+++ b/changelog
@@ -1,3 +1,13 @@
+turnkey-nextcloud-15.2 (1) turnkey; urgency=low
+
+  * Auto-detect latest upstream version
+
+  * Updated to latest upstream version
+
+  * Updated to PHP 7.2
+
+ -- Stefan Davis <stefan@turnkeylinux.org>  Tue, 14 May 2019 23:38:57 +0000
+
 turnkey-nextcloud-15.1 (1) turnkey; urgency=low
 
   * Upgraded to the latest upstream Nextcloud - v14.0.3.

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -1,11 +1,14 @@
 #!/bin/bash -ex
 
+RELEASES="$(gh_releases nextcloud/server)"
+VER=$(echo "${RELEASES}" | grep -vi RC | grep -vi beta \
+    | grep -vi alpha | sort --version-sort | tail -1 | sed 's/^v//')
+
 dl() {
     [ "$FAB_HTTP_PROXY" ] && PROXY="--proxy $FAB_HTTP_PROXY"
     cd $2; curl -L -f $PROXY $1 > $3; cd -
 }
 
-VER="14.0.3"
 URL="https://download.nextcloud.com/server/releases/nextcloud-${VER}.zip"
 
 dl $URL /usr/local/src nextcloud-$VER.zip

--- a/conf.d/main
+++ b/conf.d/main
@@ -53,4 +53,4 @@ service mysql stop
 service apache2 stop
 
 #password change in inithooks fails with the default 32M limit
-sed -i s/32M/128M/ /etc/php/7.0/cli/php.ini
+sed -i s/32M/128M/ /etc/php/7.*/cli/php.ini

--- a/conf.d/main
+++ b/conf.d/main
@@ -45,6 +45,27 @@ php occ maintenance:install --database "mysql" \
 --database-name "$DB_NAME"  --database-user "$DB_USER" --database-pass "$DB_PASS" \
 --admin-user "$ADMIN_NAME" --admin-pass "$ADMIN_PASS"
 
+# adjust nextcloud config for redis
+sed -i '/^);/d' /var/www/nextcloud/config/config.php
+cat <<EOF >> /var/www/nextcloud/config/config.php
+  'memcache.local' => '\OC\Memcache\Redis',
+  'redis' => array(
+      'host' => '/var/run/redis/redis.sock',
+      'port' => 0,
+      'timeout' => 0.0
+  ),
+  'filelocking.enabled' => true,
+  'memcache.locking' => '\OC\Memcache\Redis',
+);
+EOF
+
+# add www-data user to redis group
+usermod -a -G redis www-data
+
+# adjust redis config
+sed -i 's|# unixsocket .*|unixsocket /var/run/redis/redis.sock|g' /etc/redis/redis.conf
+sed -i 's|# unixsocketperm .*|unixsocketperm 770|g' /etc/redis/redis.conf
+
 chown -R root:root $WEBROOT
 chown -R www-data:www-data /var/www/nextcloud/{config,apps,data}
 

--- a/overlay/etc/apache2/sites-available/nextcloud.conf
+++ b/overlay/etc/apache2/sites-available/nextcloud.conf
@@ -13,6 +13,10 @@ ServerName localhost
     SSLEngine on
     ServerAdmin webmaster@localhost
     DocumentRoot /var/www/nextcloud/
+
+    <IfModule mod_headers.c>
+      Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"
+    </IfModule>
 </VirtualHost>
 
 <Directory /var/www/nextcloud/>

--- a/plan/main
+++ b/plan/main
@@ -10,6 +10,11 @@ php7.2-xml
 php7.2-mbstring
 php7.2-zip
 php-pear
+php-imagick
+
+redis-server
+php-igbinary
+php-redis
 
 smbclient
 php7.2-ldap

--- a/plan/main
+++ b/plan/main
@@ -1,21 +1,20 @@
 #include <turnkey/base>
-#include <turnkey/lamp>
+#include <turnkey/lamp72>
 
-php-gd
-php-cli
-php-curl
-php-json
-php-intl
-php-mcrypt
-php-xml
+php7.2-gd
+php7.2-cli
+php7.2-curl
+php7.2-json
+php7.2-intl
+php7.2-xml
+php7.2-mbstring
+php7.2-zip
 php-pear
-php-mbstring
-php-zip
 
 smbclient
-php-ldap
-php-imap
-php-gmp
+php7.2-ldap
+php7.2-imap
+php7.2-gmp
 
 bzip2
 libav-tools


### PR DESCRIPTION
Requires both  turnkeylinux/common#139 and turnkeylinux-apps/nextcloud#10 to be merged

Cleans up almost all warnings and errors in admin dashboard