### PR TITLE
17.2 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 PHP_MEMORY_LIMIT=512M
+PHP_EXTRA_PINS=libpcre2-8-0 libgd3
+PHP_VERSION=8.1
 
 include $(FAB_PATH)/common/mk/turnkey/lamp.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/changelog
+++ b/changelog
@@ -1,3 +1,11 @@
+turnkey-nextcloud-17.2 (1) turnkey; urgency=low
+
+  * Updated Nextcloud to latest upstream version - 26.0.0
+
+  * Includes PHP 8.1 (required by Nextcloud v24+).
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Sun, 26 Mar 2023 22:54:22 +0000
+
 turnkey-nextcloud-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
 
 RELEASES="$(gh_releases nextcloud/server)"
-VER=$(echo "${RELEASES}" | grep -vi RC | grep -vi beta \
-    | grep -vi alpha | sort --version-sort | tail -1 | sed 's/^v//')
+VER=$(echo "${RELEASES}" | grep -vi 'alpha\|beta\|rc' | sort --version-sort \
+                         | tail -1 | sed 's/^v//')
 
 dl() {
     [ "$FAB_HTTP_PROXY" ] && PROXY="--proxy $FAB_HTTP_PROXY"

--- a/conf.d/main
+++ b/conf.d/main
@@ -69,6 +69,3 @@ sed -i 's|# unixsocketperm .*|unixsocketperm 770|g' /etc/redis/redis.conf
 # stop services
 service mysql stop
 service apache2 stop
-
-#password change in inithooks fails with the default 32M limit
-sed -i s/32M/128M/ /etc/php/7.*/cli/php.ini

--- a/plan/main
+++ b/plan/main
@@ -1,28 +1,28 @@
 #include <turnkey/base>
-#include <turnkey/lamp>
+#include <turnkey/lamp81>
 
-php-bcmath
-php-gd
-php-cli
-php-curl
-php-json
-php-intl
-php-xml
-php-mbstring
-php-zip
-php-dom
+php8.1-bcmath
+php8.1-gd
+php8.1-cli
+php8.1-curl
+//php-json /* virtual package in sury.org */
+php8.1-intl
+php8.1-xml
+php8.1-mbstring
+php8.1-zip
+php8.1-dom
 php-pear
-php-imagick
+php8.1-imagick
 libmagickcore-6.q16-6-extra
 
 redis-server
-php-igbinary
-php-redis
+php8.1-igbinary
+php8.1-redis
 
 smbclient
-php-ldap
-php-imap
-php-gmp
+php8.1-ldap
+php8.1-imap
+php8.1-gmp
 
 bzip2
 ffmpeg


### PR DESCRIPTION
Update Nextcloud to latest release and install PHP 8.1 (required for Nextcloud v24+).