### PR TITLE
Fixed path to cron.php

### DIFF
--- a/overlay/etc/cron.d/nextcloud
+++ b/overlay/etc/cron.d/nextcloud
@@ -1,2 +1,2 @@
 # run cron.php for nextcloud
-*/15 * * * * www-data 	/usr/bin/php -f /var/www/nextcloud/occ /dev/null 2>&1
+*/15 * * * * www-data 	/usr/bin/php -f /var/www/nextcloud/cron.php /dev/null 2>&1


### PR DESCRIPTION
Corrected the path to the cron.php file, so the nextcloud cron job can run properly.

closes https://github.com/turnkeylinux/tracker/issues/1825