### PR TITLE
Improved inithook

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,9 +1,15 @@
 turnkey-nextcloud-18.1 (1) turnkey; urgency=low
 
-  * Update Nextcloud to latest upstream version - v29.0.3.
+  * Update Nextcloud to latest upstream version - v29.0.4.
 
   * Update Nextcloud specific inithook to manage password setting better -
     closes #1901.
+
+  * Improve turnkey-occ script.
+
+  * Remove some systemd ervice hardening for containers that include redis.
+
+  * v18.1 rebuild - includes latest Debian & TurnKey packages.
 
   * Configuration console (confconsole) - v2.1.6:
      - Bugfix broken DNS-01 Let's Encrypt challenge - closes #1876 & #1895.
@@ -33,7 +39,7 @@ turnkey-nextcloud-18.1 (1) turnkey; urgency=low
     php.ini via appliance Makefile (PHP_MAX_EXECUTION_TIME &
     PHP_MAX_INPUT_VARS).
 
- -- Jeremy Davis <jeremy@turnkeylinux.org>  Sat, 06 Jul 2024 13:48:36 +0000
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Mon, 22 Jul 2024 07:39:49 +0000
 
 turnkey-nextcloud-18.0 (1) turnkey; urgency=low
 

--- a/changelog
+++ b/changelog
@@ -2,6 +2,9 @@ turnkey-nextcloud-18.1 (1) turnkey; urgency=low
 
   * Update Nextcloud to latest upstream version - v29.0.3.
 
+  * Update Nextcloud specific inithook to manage password setting better -
+    closes #1901.
+
   * Configuration console (confconsole) - v2.1.6:
      - Bugfix broken DNS-01 Let's Encrypt challenge - closes #1876 & #1895.
       Fixed in v2.1.5.

--- a/conf.d/main
+++ b/conf.d/main
@@ -3,15 +3,15 @@
 DB_NAME=nextcloud
 DB_USER=nextcloud
 DB_PASS=$(mcookie)
-ADMIN_NAME=admin
-ADMIN_PASS=turnkey
+ADMIN_NAME="admin"
+ADMIN_PASS=$(mcookie)
 
 WEBROOT=/var/www/nextcloud
 DATAROOT=${WEBROOT}-data
 CONF=$WEBROOT/config/config.php
 
 # unpack tarball to webroot and set permissions
-unzip /usr/local/src/nextcloud*.zip -d $(dirname $WEBROOT)
+unzip /usr/local/src/nextcloud*.zip -d "$(dirname $WEBROOT)"
 [[ ! -d "$WEBROOT" ]] && exit 1
 rm -rf /usr/local/src/nextcloud*
 mkdir -p $DATAROOT
@@ -25,6 +25,8 @@ success() { echo "SUCCESS: $*"; }
 
 # vars
 template="$WEBROOT/core/templates/layout.guest.php"
+# $theme is a string not a var
+# shellcheck disable=SC2016
 search='$theme->getLongFooter()'
 replace='<a href="https://www.turnkeylinux.org/nextcloud">NextCloud Appliance</a><br>Powered by <a href="https://www.turnkeylinux.org">TurnKey Linux</a>'
 
@@ -35,7 +37,7 @@ if [[ -f "$template" ]]; then
     if [[ $instance -eq 0 ]]; then
         error "no instances of search term '$search' found in $template"
     elif [[ $instance -eq 1 ]]; then
-        success "exactly $instances of '$search' found in $template"
+        success "exactly $instance of '$search' found in $template"
         sed -i "/$search/ s|$search|'$replace'|" "$template"
     else
         error "$instance of '$search' found in $template"

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -53,6 +53,7 @@ def set_password(password, interactive):
 
 
 def main():
+    exit_code = 0
     opts = []
     try:
         opts, args = getopt.gnu_getopt(sys.argv[1:], "h",
@@ -84,6 +85,7 @@ def main():
                 prefix = "Please try again\n"
     else:
         if not set_password(password, False):
+            exit_code = 1
             chars = string.ascii_letters + string.digits + string.punctuation
             new_pass = ''.join(random.choices(chars, k=36))
             print(f"Setting password '{password}' failed", file=sys.stderr)
@@ -110,6 +112,8 @@ def main():
     conf = '/var/www/nextcloud/config/config.php'
     subprocess.call(['sed', '-i', "/1 => /d", conf])
     subprocess.call(['sed', '-i', sedcom % domain, conf])
+
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -10,14 +10,16 @@ Option:
 import sys
 import getopt
 import subprocess
-import time
 import os
 import random
 import string
 
 from libinithooks.dialog_wrapper import Dialog
+from libinithooks.inithooks_log import InitLog
+from libinithooks import inithooks_cache
 
 DEFAULT_DOMAIN = "www.example.com"
+log = InitLog("nextcloud")
 
 
 def usage(s=None):
@@ -28,78 +30,160 @@ def usage(s=None):
     sys.exit(1)
 
 
-def set_password(password, interactive):
+def set_password(password: str) -> tuple[int, str]:
+    """Set Nextcloud password - returns code & message
+    - if succcessful - return 0
+    - if password complexity failure - return 1
+    - if exception - return 2
+    - other unknown error - return 3
+    """
     local_env = os.environ.copy()
     local_env["OC_PASS"] = password
-    success = True
-    try:
-        subprocess.run(
-                    args=['/usr/local/bin/turnkey-occ', 'user:resetpassword',
-                          '--password-from-env', 'admin'],
-                    cwd='/var/www/nextcloud',
-                    env=local_env,
-                    text=True,
-                    capture_output=True,
-                    check=True)
-    except subprocess.CalledProcessError as e:
-        success = False
-        print(e.stdout)
-        print(e.stderr, file=sys.stderr)
-        # if interactive, ideally we should wait for user to read and then
-        # click an 'ok' button, but 10 sec sleep will do for now
-        if interactive:
-            time.sleep(10)
-    return success
+    p = subprocess.run(
+        args=[
+            "/usr/local/bin/turnkey-occ",
+            "user:resetpassword",
+            "--password-from-env",
+            "admin",
+        ],
+        cwd="/var/www/nextcloud",
+        env=local_env,
+        text=True,
+        capture_output=True,
+    )
+
+    # password successfully set
+    if p.returncode == 0:
+        log.write("admin password set")
+        return (0, "")
+
+    # failure/error handling
+    else:
+        skip_pass = ("\nTo skip setting password: Skip-password"
+                     "\n\t- set manually later")
+        rand_pass = ("\nTo set random password: Random1234"
+                     "\n\t- check log for password")
+        # occ seems to only output to stdout - even if stacktrace
+        # so write stdout to log regardless
+        log.write(p.stdout, "err")
+
+        # password complexity failure
+        if "password" in p.stdout.lower():
+            error_code = 1
+            msg = f"{p.stdout}{rand_pass}"
+
+        # nextcloud exception
+        elif "exception" in p.stdout.lower():
+            error_code = 2
+            head = "Nextcloud exception: "
+            tail = ("\nAre all services running?"
+                    f"\nCheck Inithooks log for info{skip_pass}")
+            if "redis" in p.stdout.lower():
+                msg = f"{head}Redis problem{tail}"
+            elif "database":
+                msg = f"{head}Database problem{tail}"
+            else:
+                msg = f"{head}Unknown problem{tail}"
+
+        # some other error
+        else:
+            error_code = 3
+            msg = f"Unexpected Nextcloud error{tail_top}{skip_pass}{skip_pass}"
+
+        return (error_code, f"\n{msg}")
+
+
+def set_random_pass():
+    chars = string.ascii_letters + string.digits + string.punctuation
+    random_pass = "".join(random.choices(chars, k=36))
+    while True:
+        password = set_password(random_pass)
+        match password[0]:
+            case 0:
+                # success
+                log.write(f"admin random password: {random_pass}", "warn")
+                return
+            case 1:
+                # should occur only in extremely rare cases
+                # trying again should work
+                continue
+            case _:
+                # exceptions and unknown errors
+                log.write(
+                    f"password setting failed - left unset:"
+                    f"\n{password[1]}", "err"
+                )
+                return
 
 
 def main():
     exit_code = 0
     opts = []
     try:
-        opts, args = getopt.gnu_getopt(sys.argv[1:], "h",
-                                       ['help', 'pass=', 'domain='])
+        opts, args = getopt.gnu_getopt(sys.argv[1:], "h", ["help",
+                                       "pass=", "domain="])
     except getopt.GetoptError as e:
         usage(e)
 
     password = ""
     domain = ""
     for opt, val in opts:
-        if opt in ('-h', '--help'):
+        if opt in ("-h", "--help"):
             usage()
-        elif opt == '--pass':
+        elif opt == "--pass":
             password = val
-        elif opt == '--domain':
+        elif opt == "--domain":
             domain = val
+
     if not password:
-        prefix = ""
-        d = Dialog('TurnKey GNU/Linux - First boot configuration')
+        message = "Enter new password for the Nextcloud 'admin' account."
+        d = Dialog("TurnKey GNU/Linux - First boot configuration")
         while True:
             password = d.get_password(
                 "Nextcloud Password",
-                prefix + "Enter new password for the Nextcloud 'admin'"
-                " account.",
-                pass_req=10)
-            if set_password(password, True):
+                message,
+                pass_req=10,
+            )
+            assert password is not None
+            match password:
+                case "Random1234":
+                    password = set_random_pass()
+                    exit_code = 1
+                    break
+                case "Skip-password":
+                    log.write("admin password not set - please set manually",
+                              "err")
+                    exit_code = 1
+                    break
+                case _:
+                    new_password = set_password(password)
+            if new_password[0] == 0:
                 break
             else:
-                prefix = "Please try again\n"
+                message = new_password[1]
     else:
-        if not set_password(password, False):
+        cli_password = set_password(password)
+        if cli_password[0] != 0:
+            log.write("setting admin password failed", "err")
             exit_code = 1
-            chars = string.ascii_letters + string.digits + string.punctuation
-            new_pass = ''.join(random.choices(chars, k=36))
-            print(f"Setting password '{password}' failed", file=sys.stderr)
-            print(f"Setting random password: {new_pass}", file=sys.stderr)
-            set_password(new_pass, False)
+            if cli_password[0] == 1:
+                set_random_pass()
+            else:
+                log.write("admin password not set - please set manually",
+                          "err")
 
     if not domain:
-        if 'd' not in locals():
-            d = Dialog('TurnKey GNU/Linux - First boot configuration')
+        prefilled_domain = inithooks_cache.read("APP_DOMAIN")
+        if not prefilled_domain:
+            prefilled_domain = DEFAULT_DOMAIN
+        if "d" not in locals():
+            d = Dialog("TurnKey GNU/Linux - First boot configuration")
 
         domain = d.get_input(
             "Nextcloud Domain",
             "Enter the domain to serve Nextcloud.",
-            DEFAULT_DOMAIN)
+            prefilled_domain
+        )
 
     if domain == "DEFAULT":
         domain = DEFAULT_DOMAIN
@@ -109,9 +193,11 @@ def main():
     1 => '%s',
     """
 
-    conf = '/var/www/nextcloud/config/config.php'
-    subprocess.call(['sed', '-i', "/1 => /d", conf])
-    subprocess.call(['sed', '-i', sedcom % domain, conf])
+    inithooks_cache.write("APP_DOMAIN", domain)
+
+    conf = "/var/www/nextcloud/config/config.php"
+    subprocess.call(["sed", "-i", "/1 => /d", conf])
+    subprocess.call(["sed", "-i", sedcom % domain, conf])
 
     sys.exit(exit_code)
 

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -173,9 +173,7 @@ def main():
                           "err")
 
     if not domain:
-        prefilled_domain = inithooks_cache.read("APP_DOMAIN")
-        if not prefilled_domain:
-            prefilled_domain = DEFAULT_DOMAIN
+        prefilled_domain = inithooks_cache.read("APP_DOMAIN", DEFAULT_DOMAIN)
         if "d" not in locals():
             d = Dialog("TurnKey GNU/Linux - First boot configuration")
 

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -110,7 +110,7 @@ def set_random_pass() -> tuple[int, str]:
         if (
             any(c.islower() for c in random_pass)
             and any(c.isupper() for c in random_pass)
-            and sum(c.isdigit() for c in random_pass)
+            and any(c.isdigit() for c in random_pass)
         ):
             break
     while True:
@@ -208,9 +208,7 @@ def main():
             else:
                 hook_exit_code = 1
                 if exit_code == ERR_EXCEPTION:
-                    print(services)
                     for service in services:
-                        print(service)
                         msg = f"{msg}\n - failed to connect to: {service}"
                 else:
                     msg = ("An unrecognised error has occured:"
@@ -235,7 +233,11 @@ def main():
                           " manually set a password once resolved")
                 break
             elif choice == "Random":
-                _ = set_random_pass()
+                exit_code, msg = set_random_pass()
+                if exit_code != 0:
+                    hook_exit_code = 1
+                    d.error(f"{msg}\n\n Ok to continue and check logs"
+                            " to debug issue")
                 break
             else:  # choice == "Retry"
                 log.write("Retrying setting password", "info")
@@ -247,8 +249,8 @@ def main():
             log.write("setting admin password failed", "err")
             hook_exit_code = 1
             if exit_code == ERR_PASSWORD:
-                _, _ = set_random_pass()
-            else:
+                exit_code, _ = set_random_pass()
+            if exit_code != 0:
                 log.write("admin password not set due to Nextcloud error/s"
                           " - resolve problem and set manually",
                           "err")

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -60,9 +60,9 @@ def set_password(password: str) -> tuple[int, str]:
     # failure/error handling
     else:
         skip_pass = ("\nTo skip setting password: Skip-password"
-                     "\n\t- set manually later")
+                     "\n- fix issues & set password manually")
         rand_pass = ("\nTo set random password: Random1234"
-                     "\n\t- check log for password")
+                     "\n- see inithooks log for password")
         # occ seems to only output to stdout - even if stacktrace
         # so write stdout to log regardless
         log.write(p.stdout, "err")
@@ -77,8 +77,9 @@ def set_password(password: str) -> tuple[int, str]:
             error_code = 2
             head = "Nextcloud exception: "
             tail = ("\nAre all services running?"
-                    f"\nCheck Inithooks log for info{skip_pass}")
+                    f" See Inithooks log for info{skip_pass}")
             if "redis" in p.stdout.lower():
+                tail = tail.format('redis')
                 msg = f"{head}Redis problem{tail}"
             elif "database":
                 msg = f"{head}Database problem{tail}"
@@ -88,7 +89,7 @@ def set_password(password: str) -> tuple[int, str]:
         # some other error
         else:
             error_code = 3
-            msg = f"Unexpected Nextcloud error{tail_top}{skip_pass}{skip_pass}"
+            msg = f"Unexpected Nextcloud error{rand_pass}{skip_pass}"
 
         return (error_code, f"\n{msg}")
 
@@ -173,7 +174,9 @@ def main():
                           "err")
 
     if not domain:
-        prefilled_domain = inithooks_cache.read("APP_DOMAIN", DEFAULT_DOMAIN)
+        prefilled_domain = inithooks_cache.read("APP_DOMAIN")
+        if not prefilled_domain:
+            prefilled_domain = DEFAULT_DOMAIN
         if "d" not in locals():
             d = Dialog("TurnKey GNU/Linux - First boot configuration")
 

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -174,16 +174,13 @@ def main():
                           "err")
 
     if not domain:
-        prefilled_domain = inithooks_cache.read("APP_DOMAIN")
-        if not prefilled_domain:
-            prefilled_domain = DEFAULT_DOMAIN
         if "d" not in locals():
             d = Dialog("TurnKey GNU/Linux - First boot configuration")
 
         domain = d.get_input(
             "Nextcloud Domain",
             "Enter the domain to serve Nextcloud.",
-            prefilled_domain
+            DEFAULT_DOMAIN
         )
 
     if domain == "DEFAULT":

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -21,6 +21,10 @@ from libinithooks import inithooks_cache
 DEFAULT_DOMAIN = "www.example.com"
 log = InitLog("nextcloud")
 
+ERR_PASSWORD = 1
+ERR_SERVICE = 2
+ERR_UNKNOWN = 3
+
 
 def usage(s=None):
     if s:
@@ -33,9 +37,9 @@ def usage(s=None):
 def set_password(password: str) -> tuple[int, str]:
     """Set Nextcloud password - returns code & message
     - if succcessful - return 0
-    - if password complexity failure - return 1
-    - if exception - return 2
-    - other unknown error - return 3
+    - if password complexity failure - return ERR_PASSWORD
+    - if exception - return ERR_SERVICE
+    - other unknown error - return ERR_UNKNOWN
     """
     local_env = os.environ.copy()
     local_env["OC_PASS"] = password
@@ -69,12 +73,12 @@ def set_password(password: str) -> tuple[int, str]:
 
         # password complexity failure
         if "password" in p.stdout.lower():
-            error_code = 1
+            error_code = ERR_PASSWORD
             msg = f"{p.stdout}{rand_pass}"
 
         # nextcloud exception
         elif "exception" in p.stdout.lower():
-            error_code = 2
+            error_code = ERR_SERVICE
             head = "Nextcloud exception: "
             tail = ("\nAre all services running?"
                     f" See Inithooks log for info{skip_pass}")
@@ -88,7 +92,7 @@ def set_password(password: str) -> tuple[int, str]:
 
         # some other error
         else:
-            error_code = 3
+            error_code = ERR_UNKNOWN
             msg = f"Unexpected Nextcloud error{rand_pass}{skip_pass}"
 
         return (error_code, f"\n{msg}")

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -13,6 +13,7 @@ import subprocess
 import os
 import random
 import string
+import secrets
 
 from libinithooks.dialog_wrapper import Dialog
 from libinithooks.inithooks_log import InitLog
@@ -99,8 +100,15 @@ def set_password(password: str) -> tuple[int, str]:
 
 
 def set_random_pass():
-    chars = string.ascii_letters + string.digits + string.punctuation
-    random_pass = "".join(random.choices(chars, k=36))
+    alphabet = string.ascii_letters + string.digits
+    while True:
+        random_pass = ''.join(secrets.choice(alphabet) for _ in range(32))
+        if (
+            any(c.islower() for c in random_pass)
+            and any(c.isupper() for c in random_pass)
+            and sum(c.isdigit() for c in random_pass)
+        ):
+            break
     while True:
         password = set_password(random_pass)
         match password[0]:

--- a/overlay/usr/lib/inithooks/bin/nextcloud.py
+++ b/overlay/usr/lib/inithooks/bin/nextcloud.py
@@ -114,7 +114,10 @@ def set_random_pass():
         match password[0]:
             case 0:
                 # success
-                log.write(f"admin random password: {random_pass}", "warn")
+                pass_file = "/root/nextcloud_random_password"
+                with open(pass_file) as fob:
+                    fob.write(f"{random_pass}\n")
+                log.write(f"admin random password set: see {pass_file}", "warn")
                 return
             case 1:
                 # should occur only in extremely rare cases

--- a/overlay/usr/local/bin/turnkey-occ
+++ b/overlay/usr/local/bin/turnkey-occ
@@ -5,6 +5,6 @@
 NC_USR=${NC_USR:-www-data}
 OCC=/var/www/nextcloud/occ
 
-COMMAND="/usr/bin/php $OCC $@"
+COMMAND="/usr/bin/php $OCC $(printf '%q ' "$@")"
 
 runuser $NC_USR -s /bin/bash -c "$COMMAND"


### PR DESCRIPTION
Improve Nextcloud inithook to deal with failed password setting better; both interactively and non-interactively.

Requires https://github.com/turnkeylinux/inithooks/pull/56

[updated]

<s>I assume that https://github.com/turnkeylinux/tracker/issues/1901 is caused by excessive Nextcloud output if setting the password fails. Nextcloud does it's own password checks and the output was being echoed via dialog.</s> I have now confirmed that the inithook stacktrace was caused by Nextcloud throwing an exception - thus returning too much text for our dialog wrapper to cope with.

When running non-interactively, rather than getting "stuck" if the password fails for any reason, it will now attempt to set a random password and allow the inithooks to continue. If setting a random password succedds it is written to the log. If it fails, then password setting will be skipped. All Nextcloud password status info is logged, as well as Nextloud verbatim output - including error messages and stacktraces.

When running interactively, this update ensures that password failure output from Nextcloud is returned via the dialog. If Nextcloud throws an exception, a simple message is returned via the dialog. An option to skip setting a password is now provided to workaround non-recoverable Nextcloud exceptions.

Unless a password is set successfully, the Nextcloud inithook will return `1`.

Also other linting fixes, including minor style changes/improvements.

Closes https://github.com/turnkeylinux/tracker/issues/1898 &  https://github.com/turnkeylinux/tracker/issues/1901 (duplicate).