### PR TITLE
Fix cronjobs not running on Turnkey Nextcloud

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,15 @@
+turnkey-nextcloud-18.2-UNFINISHED (1) turnkey; urgency=low
+
+  * Update Nextcloud to latest upstream version - vXXXX
+
+  * Bugfix: Fix Nextcloud cron job - closes #2054.
+    [ Salvatore Martire <https://github.com/salmart-dev> ]
+
+  * v18.1 rebuild - includes latest Debian & TurnKey packages - various
+    bugfixes and improvements.
+
+ -- TODO: sign off
+
 turnkey-nextcloud-18.1 (1) turnkey; urgency=low
 
   * Update Nextcloud to latest upstream version - v29.0.4.

--- a/overlay/etc/cron.d/nextcloud
+++ b/overlay/etc/cron.d/nextcloud
@@ -1,2 +1,2 @@
 # run cron.php for nextcloud
-*/15 * * * * www-data 	/usr/bin/php -f /var/www/nextcloud/cron.php /dev/null 2>&1
+*/15 * * * * www-data 	/usr/bin/php -f /var/www/nextcloud/cron.php > /dev/null 2>&1


### PR DESCRIPTION
# Problem

There was a missing > in the command to run cron.php.

# Outcomes
The problem resulted in cronjobs never running any jobs as the `/dev/null` is passed as argument to `cron.php` due to the missing `>` and is interpreted as class name, which obviously does not exist.

----

closes https://github.com/turnkeylinux/tracker/issues/2054